### PR TITLE
ISR functions should be defined with ICACHE_RAM_ATTR attribute.

### DIFF
--- a/RH_RF69.h
+++ b/RH_RF69.h
@@ -930,13 +930,13 @@ protected:
 
 protected:
     /// Low level interrupt service routine for RF69 connected to interrupt 0
-    static void         isr0();
+    static void ICACHE_RAM_ATTR isr0();
 
     /// Low level interrupt service routine for RF69 connected to interrupt 1
-    static void         isr1();
+    static void ICACHE_RAM_ATTR isr1();
 
     /// Low level interrupt service routine for RF69 connected to interrupt 1
-    static void         isr2();
+    static void ICACHE_RAM_ATTR isr2();
 
     /// Array of instances connected to interrupts 0 and 1
     static RH_RF69*     _deviceForInterrupt[];


### PR DESCRIPTION
ISR functions should be defined with ICACHE_RAM_ATTR attribute to let the compiler know to never remove them from the IRAM.
If the ICACHE_RAM_ATTR attribute is missing the firmware will crash at the first call to attachInterrupt() on a ISR routine that happens not to be in ram at that moment.

This bug will manifest itself only on some platform and some code configurations, as it entirely depends of where the compiler chooses to put the ISR functions.

More informations here:

https://stackoverflow.com/questions/58113937/esp8266-arduino-why-is-it-necessary-to-add-the-icache-ram-attr-macro-to-isrs-an